### PR TITLE
[layerzero OFT] change graphQL schema

### DIFF
--- a/src/mappings/wooTokenOFT/index.ts
+++ b/src/mappings/wooTokenOFT/index.ts
@@ -12,14 +12,14 @@ export function handleOFTReceived(event: OFTReceivedEvent): void {
   let entity = new OFTReceived(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   );
-  entity.guid = event.params.guid;
+  entity.guid = event.params.guid.toHexString();
   entity.srcEid = event.params.srcEid;
-  entity.toAddress = event.params.toAddress;
+  entity.toAddress = event.params.toAddress.toHexString();
   entity.amountReceivedLD = event.params.amountReceivedLD;
 
   entity.blockNumber = event.block.number;
   entity.blockTimestamp = event.block.timestamp;
-  entity.transactionHash = event.transaction.hash;
+  entity.transactionHash = event.transaction.hash.toHexString();
 
   entity.save();
 }
@@ -28,15 +28,15 @@ export function handleOFTSent(event: OFTSentEvent): void {
   let entity = new OFTSent(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   );
-  entity.guid = event.params.guid;
+  entity.guid = event.params.guid.toHexString();
   entity.dstEid = event.params.dstEid;
-  entity.fromAddress = event.params.fromAddress;
+  entity.fromAddress = event.params.fromAddress.toHexString();
   entity.amountSentLD = event.params.amountSentLD;
   entity.amountReceivedLD = event.params.amountReceivedLD;
 
   entity.blockNumber = event.block.number;
   entity.blockTimestamp = event.block.timestamp;
-  entity.transactionHash = event.transaction.hash;
+  entity.transactionHash = event.transaction.hash.toHexString();
 
   entity.save();
 }

--- a/subgraphs/woofi.graphql
+++ b/subgraphs/woofi.graphql
@@ -355,23 +355,23 @@ type StargateBridgeSendMsg @entity {
 
 type OFTSent @entity(immutable: true) {
   id: Bytes!
-  guid: Bytes! # bytes32
+  guid: String! # bytes32
   dstEid: BigInt! # uint32
-  fromAddress: Bytes! # address
+  fromAddress: String! # address
   amountSentLD: BigInt! # uint256
   amountReceivedLD: BigInt! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
-  transactionHash: Bytes!
+  transactionHash: String!
 }
 
 type OFTReceived @entity(immutable: true) {
   id: Bytes!
-  guid: Bytes! # bytes32
+  guid: String! # bytes32
   srcEid: BigInt! # uint32
-  toAddress: Bytes! # address
+  toAddress: String! # address
   amountReceivedLD: BigInt! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
-  transactionHash: Bytes!
+  transactionHash: String!
 }


### PR DESCRIPTION
change guid / from / to to string, because for Solana tx and account address are all bs58 encoded, it was inconvenient to store account in byte array, so store them in string for consistency

![Xnip2025-02-19_10-31-55](https://github.com/user-attachments/assets/eab706a5-0b5f-40d2-9edd-e52fd914471c)


@fb-alexcq @0xmer1in 