### PR TITLE
[bug fix] fix OFT entity id

### DIFF
--- a/src/mappings/wooTokenOFT/index.ts
+++ b/src/mappings/wooTokenOFT/index.ts
@@ -9,9 +9,8 @@ import {
 import { Bytes } from "@graphprotocol/graph-ts"
 
 export function handleOFTReceived(event: OFTReceivedEvent): void {
-  let entity = new OFTReceived(
-    event.transaction.hash.concatI32(event.logIndex.toI32())
-  );
+  let entityID = event.transaction.hash.toHexString().concat("-").concat(event.logIndex.toString());
+  let entity = new OFTReceived(entityID);
   entity.guid = event.params.guid.toHexString();
   entity.srcEid = event.params.srcEid;
   entity.toAddress = event.params.toAddress.toHexString();
@@ -25,9 +24,8 @@ export function handleOFTReceived(event: OFTReceivedEvent): void {
 }
 
 export function handleOFTSent(event: OFTSentEvent): void {
-  let entity = new OFTSent(
-    event.transaction.hash.concatI32(event.logIndex.toI32())
-  );
+  let entityID = event.transaction.hash.toHexString().concat("-").concat(event.logIndex.toString());
+  let entity = new OFTSent(entityID);
   entity.guid = event.params.guid.toHexString();
   entity.dstEid = event.params.dstEid;
   entity.fromAddress = event.params.fromAddress.toHexString();

--- a/subgraphs/woofi.graphql
+++ b/subgraphs/woofi.graphql
@@ -354,7 +354,7 @@ type StargateBridgeSendMsg @entity {
 }
 
 type OFTSent @entity(immutable: true) {
-  id: Bytes!
+  id: ID!
   guid: String! # bytes32
   dstEid: BigInt! # uint32
   fromAddress: String! # address
@@ -366,7 +366,7 @@ type OFTSent @entity(immutable: true) {
 }
 
 type OFTReceived @entity(immutable: true) {
-  id: Bytes!
+  id: ID!
   guid: String! # bytes32
   srcEid: BigInt! # uint32
   toAddress: String! # address


### PR DESCRIPTION
I was testing Solana integration and the EVM Id reports error:

```
[2025-03-03 19:42:14,984:subgraph.py:30:_post_content] https://api.studio.thegraph.com/query/71937/woofi-base-staging/version/latest
[2025-03-03 19:42:14,989:subgraph.py:31:_post_content] {'query': '{\n            oftsents(first: 200, orderBy: blockTimestamp, orderDirection: desc,  where: {fromAddress: "BhTpGbF7gBUiGjESQHVoBNhx2iy7Y21L2hAhRPdNT5ZF", }) {\n                guid\n                dstEid\n                fromAddress\n                amountSentLD\n                amountReceivedLD\n                blockNumber\n                blockTimestamp\n                transactionHash\n            }\n            oftreceiveds(first: 200, orderBy: blockTimestamp, orderDirection: desc,  where: {toAddress: "BhTpGbF7gBUiGjESQHVoBNhx2iy7Y21L2hAhRPdNT5ZF", }) {\n                guid\n                srcEid\n                toAddress\n                amountReceivedLD\n                blockNumber\n                blockTimestamp\n                transactionHash\n            }\n        }', 'variables': {}}
[2025-03-03 19:42:15,543:subgraph.py:41:_post_content] {"errors":[{"message":"Failed to decode `Bytes` value: `Invalid character 'h' at position 1`"},{"message":"Failed to decode `Bytes` value: `Invalid character 'h' at position 1`"}]}
```

@0xmer1in 